### PR TITLE
fix: Add DEBUG_LOG_DIR to specify debug log location

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,9 +145,10 @@ Enable detailed debug logging:
 ```
 DEBUG=1              # Enable debug mode
 MCP_DEBUG=1          # Alternative debug flag
+DEBUG_LOG_DIR=/path  # Custom log directory (optional, defaults to current working directory)
 ```
 
-When enabled, creates detailed Markdown debug logs in `logs/debug/` directory containing:
+When enabled, creates detailed Markdown debug logs in `logs/debug/` directory (or `DEBUG_LOG_DIR/debug/` if custom path is set) containing:
 - Full provider requests and responses
 - Question text and timestamps
 - Response content (truncated for readability)
@@ -170,6 +171,7 @@ Debug logs are human-readable and ideal for:
       "args": ["-y", "@bagros/mcp-research-router"],
       "env": {
         "DEBUG": "1",
+        "DEBUG_LOG_DIR": "/Users/yourname/Projects/your-project",
         "OPENAI_API_KEY": "sk-...",
         "GOOGLE_API_KEY": "...",
         "PERPLEXITY_API_KEY": "...",
@@ -179,6 +181,8 @@ Debug logs are human-readable and ideal for:
   }
 }
 ```
+
+**Important:** Set `DEBUG_LOG_DIR` to the directory where you want debug logs saved. The system will create a `debug/` subdirectory there. If not set, logs will be saved in the current working directory (which may be the npm package installation directory when using npx).
 
 ## MCP Tools
 


### PR DESCRIPTION
Problem: Debug logs were being saved to process.cwd() which could be the npm package installation directory when using npx, making logs hard to find for users.

Solution:
1. Add DEBUG_LOG_DIR environment variable to allow users to specify where debug logs should be saved
2. Default to process.cwd()/logs/debug if not set
3. Add comprehensive diagnostic logging showing:
   - Where logs are being saved (directory and file path)
   - Current working directory
   - Whether debug mode is enabled or disabled
4. Add error handling for debug initialization failures
5. Include log location information in debug file header

Usage:
Set DEBUG_LOG_DIR=/path/to/your/project in MCP server config to save logs in a specific directory. The system will create debug/ subdirectory.

This makes it easy for users to find their debug logs in their project directory instead of searching through npm cache.

Updated CLAUDE.md with:
- DEBUG_LOG_DIR documentation
- Example configuration for Claude Desktop
- Important note about default behavior